### PR TITLE
Catch exceptions

### DIFF
--- a/app/Console/Commands/FetchCoinsPrices.php
+++ b/app/Console/Commands/FetchCoinsPrices.php
@@ -58,8 +58,12 @@ class FetchCoinsPrices extends Command implements SignalableCommandInterface
                 UpdateCryptoAssetPrice::dispatch($asset);
                 $this->output->write('<fg=green>.</>');
             }
+            catch (\Illuminate\Http\Client\ConnectionException $exception) {
+                $this->output->write('<fg=red>Connection failed, retrying...</>');
+            }
             catch (\Exception $exception) {
-                $this->output->write('<fg=red>.</>');
+                $this->output->write('<fg=red>' . $exception->getMessage() . '</>');
+                die;
             }
         });
     }

--- a/app/Console/Commands/FetchCoinsPrices.php
+++ b/app/Console/Commands/FetchCoinsPrices.php
@@ -58,7 +58,7 @@ class FetchCoinsPrices extends Command implements SignalableCommandInterface
                 UpdateCryptoAssetPrice::dispatch($asset);
                 $this->output->write('<fg=green>.</>');
             }
-            catch (Exception $exception) {
+            catch (\Exception $exception) {
                 $this->output->write('<fg=red>.</>');
             }
         });

--- a/app/Console/Commands/FetchCoinsPrices.php
+++ b/app/Console/Commands/FetchCoinsPrices.php
@@ -54,8 +54,13 @@ class FetchCoinsPrices extends Command implements SignalableCommandInterface
     protected function fetchPrices(): void
     {
         Asset::crypto()->get()->each(function (Asset $asset) {
-            UpdateCryptoAssetPrice::dispatch($asset);
-            $this->output->write('<fg=green>.</>', false);
+            try {
+                UpdateCryptoAssetPrice::dispatch($asset);
+                $this->output->write('<fg=green>.</>');
+            }
+            catch (Exception $exception) {
+                $this->output->write('<fg=red>.</>');
+            }
         });
     }
 


### PR DESCRIPTION
Had this command fail regularly because of exceptions thrown by cURL.
There are several different errors that cause cURL to fail and trigger an exception.
Timeout / SSL-error / etc.

Example of error:

   Illuminate\Http\Client\ConnectionException

  cURL error 35: error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://api.coinbase.com/v2/prices/ETH-USD/buy

  at vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:711
    707▕                 });
    708▕             } catch (ConnectException $e) {
    709▕                 $this->dispatchConnectionFailedEvent();
    710▕
  ➜ 711▕                 throw new ConnectionException($e->getMessage(), 0, $e);
    712▕             }
    713▕         }, $this->retryDelay ?? 100, $this->retryWhenCallback);
    714▕     }
    715▕

      +22 vendor frames
  23  app/MarketInformationProviders/Coinbase.php:21
      Illuminate\Http\Client\PendingRequest::get()

  24  app/Jobs/UpdateCryptoAssetPrice.php:38
      App\MarketInformationProviders\Coinbase::fetchAsset()

This Try/Catch block should fix that.